### PR TITLE
fix: compute batches using records_models

### DIFF
--- a/src/argilla_sdk/records/_dataset_records.py
+++ b/src/argilla_sdk/records/_dataset_records.py
@@ -152,7 +152,7 @@ class DatasetRecords(Resource, GenericExportMixin):
         )
 
         created_records = []
-        for batch in range(0, len(records), batch_size):
+        for batch in range(0, len(record_models), batch_size):
             self.log(message=f"Sending records from {batch} to {batch + batch_size}.")
             batch_records = record_models[batch : batch + batch_size]
             models = self._api.bulk_create(dataset_id=self.__dataset.id, records=batch_records)


### PR DESCRIPTION
This PR fixes problem computing batches. When adding one single record, the computed batches are wrong.  

With changes included here, the test `test_add_records.py::test_add_single_record`  will pass.