### PR TITLE
[FIX] copy password when creating a user resource

### DIFF
--- a/src/argilla_sdk/_api/_users.py
+++ b/src/argilla_sdk/_api/_users.py
@@ -37,15 +37,11 @@ class UsersAPI(ResourceAPI[UserModel]):
     @api_error_handler
     def create(self, user: UserModel) -> UserModel:
         json_body = user.model_dump()
-        response = self.http_client.post(
-            "/api/users",
-            json=json_body,
-        )
-        response.raise_for_status()
-        response_json = response.json()
-        user = self._model_from_json(response_json=response_json)
-        self.log(message=f"Created user {user.username}")
-        return user
+        response = self.http_client.post("/api/users", json=json_body).raise_for_status()
+        user_created = self._model_from_json(response_json=response.json())
+        self.log(message=f"Created user {user_created.username}")
+
+        return user_created
 
     @api_error_handler
     def get(self, user_id: UUID) -> UserModel:

--- a/src/argilla_sdk/users/_resource.py
+++ b/src/argilla_sdk/users/_resource.py
@@ -63,6 +63,15 @@ class User(Resource):
             self.log(f"Initialized user with username {username}")
         self._sync(model=_model)
 
+    def create(self) -> "Resource":
+        """Creates the user in Argilla"""
+        model_create = self.api_model()
+        model = self._api.create(model_create)
+        # The password is not returned in the response
+        model.password = model_create.password
+        self._sync(model=model)
+        return self
+
     def exists(self) -> bool:
         """Checks if the user exists in Argilla"""
         # TODO - Implement the exist method in the API

--- a/tests/integration/test_manage_users.py
+++ b/tests/integration/test_manage_users.py
@@ -21,6 +21,8 @@ class TestManageUsers:
         user.create()
         try:
             assert user.id is not None
+            assert user.password == "test_password"
+            assert user.username == "test_user"
             assert client.users(username=user.username).id == user.id
         finally:
             user.delete()

--- a/tests/unit/test_resources/test_users.py
+++ b/tests/unit/test_resources/test_users.py
@@ -21,6 +21,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 import argilla_sdk as rg
+from argilla_sdk import User
 from argilla_sdk._exceptions import (
     BadRequestError,
     ConflictError,
@@ -29,6 +30,7 @@ from argilla_sdk._exceptions import (
     NotFoundError,
     UnprocessableEntityError,
 )
+from argilla_sdk._models import UserModel
 
 
 class TestUserSerialization:
@@ -210,31 +212,6 @@ class TestUsersAPI:
             assert user.id == uuid.UUID(mock_return_value["id"])
             assert user.role == mock_return_value["role"]
 
-    # TODO: Restore this test based on server implementation
-    # def test_add_user_to_workspace(self, httpx_mock: HTTPXMock):
-    #     user_id = uuid.uuid4().hex
-    #     workspace_id = uuid.uuid4().hex
-    #     mock_workspace_user_return_value = {
-    #         "id": str(user_id),
-    #         "username": "test-user",
-    #         "password": "test-password",
-    #         "first_name": "Test",
-    #         "last_name": "User",
-    #         "role": "admin",
-    #         "inserted_at": datetime.utcnow().isoformat(),
-    #         "updated_at": datetime.utcnow().isoformat(),
-    #     }
-    #     httpx_mock.add_response(
-    #         json=mock_workspace_user_return_value, url=f"http://test_url/api/users/{user_id}", method="GET"
-    #     )
-    #     httpx_mock.add_response(url=f"http://test_url/api/v1/workspaces/{workspace_id}/users/{user_id}", method="POST")
-    #     with httpx.Client():
-    #         client = rg.Argilla(api_url="http://test_url", api_key="admin.apikey")
-    #         user = rg.User(**mock_workspace_user_return_value)
-    #         client.api.workspaces.add_user(workspace_id, user_id)
-    #         assert user.username == gotten_user.username
-    #         assert user.id == gotten_user.id
-
     def test_remove_user_from_workspace(self, httpx_mock: HTTPXMock):
         user_id = uuid.uuid4()
         workspace_id = uuid.uuid4()
@@ -284,3 +261,25 @@ class TestUsersAPI:
             for i in range(len(users)):
                 assert users[i].username == mock_return_value[i]["username"]
                 assert users[i].id == uuid.UUID(mock_return_value[i]["id"])
+
+    def test_create_user(self, httpx_mock: HTTPXMock):
+        user_id = uuid.uuid4()
+        mock_return_value = {
+            "id": str(user_id),
+            "username": "test-user",
+            "first_name": "Test",
+            "last_name": "User",
+            "role": "admin",
+            "inserted_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        api_url = "http://test_url"
+
+        httpx_mock.add_response(json=mock_return_value, url=f"{api_url}/api/users", method="POST", status_code=200)
+        with httpx.Client():
+            client = rg.Argilla(api_url=api_url, api_key="admin.apikey")
+            user_create = UserModel(username="test-user", password="test-password")
+            user = client.api.users.create(user_create)
+            assert user.id == user_id
+            assert user.username == "test-user"
+            assert user.password is None


### PR DESCRIPTION
Otherwise, the user flow may be confusing (password will be replaced by None) since API response does not include password.