### PR TITLE
[REFACTOR] define default client mechanism

### DIFF
--- a/src/argilla_sdk/client.py
+++ b/src/argilla_sdk/client.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, overload, List, Optional, Union
 
 from argilla_sdk import _api
+from argilla_sdk._api._client import DEFAULT_HTTP_CONFIG
 from argilla_sdk._helpers import GenericIterator
 from argilla_sdk._helpers._resource_repr import ResourceHTMLReprMixin
 from argilla_sdk._models import UserModel, WorkspaceModel, DatasetModel
@@ -31,6 +32,33 @@ __all__ = ["Argilla"]
 
 
 class Argilla(_api.APIClient):
+
+    # Default instance of Argilla
+    _default_client: Optional["Argilla"] = None
+
+    def __init__(
+        self,
+        api_url: Optional[str] = DEFAULT_HTTP_CONFIG.api_url,
+        api_key: Optional[str] = DEFAULT_HTTP_CONFIG.api_key,
+        timeout: int = DEFAULT_HTTP_CONFIG.timeout,
+        **http_client_args,
+    ) -> None:
+        super().__init__(api_url=api_url, api_key=api_key, timeout=timeout, **http_client_args)
+
+        self._set_default(self)
+
+    @classmethod
+    def _set_default(cls, client: "Argilla") -> None:
+        """Set the default instance of Argilla."""
+        cls._default_client = client
+
+    @classmethod
+    def _get_default(cls) -> "Argilla":
+        """Get the default instance of Argilla. If it doesn't exist, create a new one."""
+        if cls._default_client is None:
+            cls._default_client = Argilla()
+        return cls._default_client
+
     @property
     def workspaces(self) -> "Workspaces":
         return Workspaces(client=self)

--- a/src/argilla_sdk/datasets/_resource.py
+++ b/src/argilla_sdk/datasets/_resource.py
@@ -43,7 +43,7 @@ class Dataset(Resource):
         name: Optional[str] = None,
         workspace: Optional[Union["Workspace", str]] = None,
         settings: Optional[Settings] = None,
-        client: Optional["Argilla"] = Argilla(),
+        client: Optional["Argilla"] = None,
         _model: Optional[DatasetModel] = None,
     ) -> None:
         """Initalizes a Dataset with a client and model
@@ -53,6 +53,7 @@ class Dataset(Resource):
             settings (Settings): Settings class to be used to configure the dataset.
             client (Argilla): Instance of Argilla to connect with the server.
         """
+        client = client or Argilla._get_default()
         super().__init__(client=client, api=client.api.datasets)
         if name is None:
             name = f"dataset_{uuid4()}"

--- a/src/argilla_sdk/datasets/_resource.py
+++ b/src/argilla_sdk/datasets/_resource.py
@@ -172,12 +172,13 @@ class Dataset(Resource):
         return settings
 
     def __workspace_id_from_name(self, workspace: Optional[Union["Workspace", str]]) -> UUID:
-        available_workspaces = self._client.workspaces
-        available_workspace_names = [ws.name for ws in available_workspaces]
+
         if workspace is None:
+            available_workspaces = self._client.workspaces
             ws = available_workspaces[0]  # type: ignore
             warnings.warn(f"Workspace not provided. Using default workspace: {ws.name} id: {ws.id}")
         elif isinstance(workspace, str):
+            available_workspace_names = [ws.name for ws in self._client.workspaces]
             ws = self._client.workspaces(workspace)
             if not ws.exists():
                 self.log(

--- a/src/argilla_sdk/users/_resource.py
+++ b/src/argilla_sdk/users/_resource.py
@@ -37,7 +37,7 @@ class User(Resource):
         last_name: Optional[str] = None,
         role: Optional[str] = None,
         password: Optional[str] = None,
-        client: Optional["Argilla"] = Argilla(),
+        client: Optional["Argilla"] = None,
         id: Optional[UUID] = None,
         _model: Optional[UserModel] = None,
     ) -> None:
@@ -49,6 +49,7 @@ class User(Resource):
         Returns:
             User: The initialized user object
         """
+        client = client or Argilla._get_default()
         super().__init__(client=client, api=client.api.users)
 
         if _model is None:

--- a/src/argilla_sdk/workspaces/_resource.py
+++ b/src/argilla_sdk/workspaces/_resource.py
@@ -54,7 +54,6 @@ class Workspace(Resource):
             Workspace: The initialized workspace object
         """
         client = client or Argilla._get_default()
-
         super().__init__(client=client, api=client.api.workspaces)
         self._sync(model=WorkspaceModel(name=name, id=id) if not _model else _model)
 

--- a/src/argilla_sdk/workspaces/_resource.py
+++ b/src/argilla_sdk/workspaces/_resource.py
@@ -41,7 +41,7 @@ class Workspace(Resource):
         self,
         name: Optional[str] = None,
         id: Optional[UUID] = None,
-        client: Optional["Argilla"] = Argilla(),
+        client: Optional["Argilla"] = None,
         _model: Optional[WorkspaceModel] = None,
     ) -> None:
         """Initializes a Workspace object with a client and a name or id
@@ -53,6 +53,8 @@ class Workspace(Resource):
         Returns:
             Workspace: The initialized workspace object
         """
+        client = client or Argilla._get_default()
+
         super().__init__(client=client, api=client.api.workspaces)
         self._sync(model=WorkspaceModel(name=name, id=id) if not _model else _model)
 

--- a/tests/unit/test_record_responses.py
+++ b/tests/unit/test_record_responses.py
@@ -15,13 +15,15 @@ import uuid
 
 import pytest
 
-from argilla_sdk import Response, User, Dataset, Settings, TextQuestion, TextField
+from argilla_sdk import Response, User, Dataset, Settings, TextQuestion, TextField, Workspace
 from argilla_sdk.records._resource import RecordResponses, Record
 
 
 @pytest.fixture
 def record():
+    workspace = Workspace(name="workspace", id=uuid.uuid4())
     dataset = Dataset(
+        workspace=workspace,
         settings=Settings(
             fields=[TextField(name="name")],
             allow_extra_metadata=True,
@@ -30,7 +32,7 @@ def record():
                 TextQuestion(name="question_b"),
                 TextQuestion(name="question_c"),
             ],
-        )
+        ),
     )
     return Record(fields={"name": "John Doe"}, metadata={"age": 30}, _dataset=dataset)
 
@@ -38,7 +40,7 @@ def record():
 class TestRecordResponses:
 
     def test_create_record_responses_for_single_user(self, record: Record):
-        user = User(username="johndoe", id=str(uuid.uuid4()))
+        user = User(username="johndoe", id=uuid.uuid4())
 
         responses = [
             Response(question_name="question_a", value="answer_a", user_id=user.id),
@@ -56,8 +58,8 @@ class TestRecordResponses:
         assert record_responses.question_c[0].user_id == user.id
 
     def test_create_record_responses_for_multiple_users(self, record: Record):
-        user_a = User(username="johndoe", id=str(uuid.uuid4()))
-        user_b = User(username="janedoe", id=str(uuid.uuid4()))
+        user_a = User(username="johndoe", id=uuid.uuid4())
+        user_b = User(username="janedoe", id=uuid.uuid4())
 
         responses = [
             Response(question_name="question_a", value="answer_a", user_id=user_a.id),


### PR DESCRIPTION
This PR defines a reference to the latest created argilla client as the default client and is used as the client for the resource init method if the client is not provided, instead of creating a new default one.

Note: This is not an optimal solution. We should review client instances management as a fully separate work. 