### PR TITLE
[BUG] Fix dependency error and pre-commit tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: ruff-format
   
   - repo: https://github.com/kynan/nbstripout
-    rev: v0.7.1
+    rev: 3c241ca
     hooks:
       - id: nbstripout
         files: \.ipynb$

--- a/pdm.lock
+++ b/pdm.lock
@@ -137,7 +137,7 @@ dependencies = [
     "colorama; os_name == \"nt\"",
     "importlib-metadata>=4.6; python_full_version < \"3.10.2\"",
     "packaging>=19.0",
-    "pyproject-hooks",
+    "pyproject-hooks=1.0.0",
     "tomli>=1.1.0; python_version < \"3.11\"",
 ]
 files = [


### PR DESCRIPTION
* When installing dev dependencies, this error arises: https://github.com/python-poetry/poetry/issues/9351. Fixing it by setting the version to 1.0.0, maybe 1.1.0 also works but didn't try.
* pre-commit tag is not found. Changing it to the commit id. https://github.com/kynan/nbstripout/releases/tag/0.7.1