### PR TITLE
[BUG] catch-id-in-updating-records

### DIFF
--- a/src/argilla_sdk/records/_resource.py
+++ b/src/argilla_sdk/records/_resource.py
@@ -204,6 +204,7 @@ class Record(Resource):
 
             if attribute == "id":
                 record_id = value
+                continue
 
             # Add suggestion values to the suggestions
             if attribute_type == "suggestion":

--- a/src/argilla_sdk/records/_resource.py
+++ b/src/argilla_sdk/records/_resource.py
@@ -194,7 +194,7 @@ class Record(Resource):
                     attribute_type = attribute_mapping[1]
                 if len(attribute_mapping) > 2:
                     sub_attribute = attribute_mapping[2]
-            elif schema_item is mapping is None:
+            elif schema_item is mapping is None and attribute != "id":
                 warnings.warn(
                     message=f"""Record attribute {attribute} is not in the schema so skipping. 
                         Define a mapping to map source data fields to Argilla Fields, Questions, and ids
@@ -202,10 +202,8 @@ class Record(Resource):
                 )
                 continue
 
-            # Skip if the attribute is an id or external_id
             if attribute == "id":
                 record_id = value
-                continue
 
             # Add suggestion values to the suggestions
             if attribute_type == "suggestion":

--- a/tests/integration/test_update_records.py
+++ b/tests/integration/test_update_records.py
@@ -73,22 +73,23 @@ def test_update_records_partially(client: rg.Argilla, dataset: rg.Dataset):
         {
             "text": "Hello World, how are you?",
             "label": "negative",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
             "label": "negative",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
             "label": "negative",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
     ]
     updated_mock_data = mock_data.copy()
     updated_mock_data[0]["label"] = "positive"
     dataset.records.add(records=mock_data)
     dataset.records.update(records=updated_mock_data)
+    
     for i, record in enumerate(dataset.records(with_suggestions=True)):
         assert record.suggestions[0].value == updated_mock_data[i]["label"]


### PR DESCRIPTION
This PR cataches `id` keys in ingested data structures within the from_dict method.

It expands testing in `/home/ben/code/argilla-python/tests/integration/test_update_records.py` but we should expand testing for the `from_dict` method.