### PR TITLE
[DOCS] Add more settings usage examples

### DIFF
--- a/docs/how_to_guides/dataset.md
+++ b/docs/how_to_guides/dataset.md
@@ -82,6 +82,47 @@ dataset.create()
 !!! tip "Accessing attributes"
     Access the attributes of a dataset by calling them directly on the `dataset` object. For example, `dataset.id`, `dataset.name` or `dataset.settings`. You can similarly access the fields, questions, metadata, vectors and guidelines. For instance, `dataset.fields` or `dataset.questions`.
 
+### Create multiple datasets with the same settings
+
+To create multiple datasets with the same settings, define the settings once and pass it to each dataset.
+
+```python
+import argilla_sdk as rg
+
+settings = rg.Settings(
+    guidelines="Select the sentiment of the prompt.",
+    fields=[rg.TextField(name="prompt", use_markdown=True)],
+    questions=[rg.LabelQuestion(name="sentiment", labels=["positive", "negative"])],
+)
+
+dataset1 = rg.Dataset(name="sentiment_analysis_1", settings=settings)
+dataset2 = rg.Dataset(name="sentiment_analysis_2", settings=settings)
+
+# Create the datasets on the server
+dataset1.create()
+dataset2.create()
+
+```
+
+### Create a dataset with settings from an existing dataset
+
+To create a new dataset with settings from an existing dataset, get the settings from the existing dataset and pass it
+to the new dataset.
+
+```python
+import argilla_sdk as rg
+
+# Get the settings from an existing dataset
+existing_dataset = client.datasets("sentiment_analysis")
+
+# Create a new dataset with the same settings
+dataset = rg.Dataset(name="sentiment_analysis_copy", settings=existing_dataset.settings)
+
+# Create the dataset on the server
+dataset.create()
+
+```
+
 ## Define dataset settings
 
 ### Fields

--- a/docs/reference/argilla_sdk/settings/settings.md
+++ b/docs/reference/argilla_sdk/settings/settings.md
@@ -1,12 +1,15 @@
 # `rg.Settings`
 
-`rg.Settings` is used to define the setttings of an Argilla `Dataset`. The settings can be used to configure the behavior of the dataset, such as the fields, questions, guidelines, metadata, and vectors. The `Settings` class is passed to the `Dataset` class and used to create the dataset on the server. Once created, the settings of a dataset cannot be changed. 
+`rg.Settings` is used to define the setttings of an Argilla `Dataset`. The settings can be used to configure the
+behavior of the dataset, such as the fields, questions, guidelines, metadata, and vectors. The `Settings` class is
+passed to the `Dataset` class and used to create the dataset on the server. Once created, the settings of a dataset
+cannot be changed.
 
 ## Usage Examples
 
 ### Creating a new dataset with settings
 
-To create a new dataset with settings, instantiate the `Settings` class and pass it to the `Dataset` class. 
+To create a new dataset with settings, instantiate the `Settings` class and pass it to the `Dataset` class.
 
 ```python
 import argilla_sdk as rg
@@ -17,15 +20,53 @@ settings = rg.Settings(
     questions=[rg.LabelQuestion(name="sentiment", labels=["positive", "negative"])],
 )
 
-dataset = rg.Dataset(
-    name="sentiment_analysis",
-    settings=settings,
-)
+dataset = rg.Dataset(name="sentiment_analysis", settings=settings)
 
 # Create the dataset on the server
 dataset.create()
+
 ```
 
+### Creating multiple datasets with the same settings
+
+To create multiple datasets with the same settings, define the settings once and pass it to each dataset.
+
+```python
+import argilla_sdk as rg
+
+settings = rg.Settings(
+    guidelines="Select the sentiment of the prompt.",
+    fields=[rg.TextField(name="prompt", use_markdown=True)],
+    questions=[rg.LabelQuestion(name="sentiment", labels=["positive", "negative"])],
+)
+
+dataset1 = rg.Dataset(name="sentiment_analysis_1", settings=settings)
+dataset2 = rg.Dataset(name="sentiment_analysis_2", settings=settings)
+
+# Create the datasets on the server
+dataset1.create()
+dataset2.create()
+
+```
+
+### Creating a dataset with settings from an existing dataset
+
+To create a new dataset with settings from an existing dataset, get the settings from the existing dataset and pass it
+to the new dataset.
+
+```python
+import argilla_sdk as rg
+
+# Get the settings from an existing dataset
+existing_dataset = client.datasets("sentiment_analysis")
+
+# Create a new dataset with the same settings
+dataset = rg.Dataset(name="sentiment_analysis_copy", settings=existing_dataset.settings)
+
+# Create the dataset on the server
+dataset.create()
+
+```
 
 > To define the settings for fields, questions, metadata, or vectors, refer to the [`rg.TextField`](fields.md), [`rg.LabelQuestion`](questions.md), [`rg.TermsMetadataProperty`](metadata_property.md), and [`rg.VectorField`](vectors.md) class documentation.
 

--- a/docs/reference/argilla_sdk/settings/settings.md
+++ b/docs/reference/argilla_sdk/settings/settings.md
@@ -27,47 +27,6 @@ dataset.create()
 
 ```
 
-### Creating multiple datasets with the same settings
-
-To create multiple datasets with the same settings, define the settings once and pass it to each dataset.
-
-```python
-import argilla_sdk as rg
-
-settings = rg.Settings(
-    guidelines="Select the sentiment of the prompt.",
-    fields=[rg.TextField(name="prompt", use_markdown=True)],
-    questions=[rg.LabelQuestion(name="sentiment", labels=["positive", "negative"])],
-)
-
-dataset1 = rg.Dataset(name="sentiment_analysis_1", settings=settings)
-dataset2 = rg.Dataset(name="sentiment_analysis_2", settings=settings)
-
-# Create the datasets on the server
-dataset1.create()
-dataset2.create()
-
-```
-
-### Creating a dataset with settings from an existing dataset
-
-To create a new dataset with settings from an existing dataset, get the settings from the existing dataset and pass it
-to the new dataset.
-
-```python
-import argilla_sdk as rg
-
-# Get the settings from an existing dataset
-existing_dataset = client.datasets("sentiment_analysis")
-
-# Create a new dataset with the same settings
-dataset = rg.Dataset(name="sentiment_analysis_copy", settings=existing_dataset.settings)
-
-# Create the dataset on the server
-dataset.create()
-
-```
-
 > To define the settings for fields, questions, metadata, or vectors, refer to the [`rg.TextField`](fields.md), [`rg.LabelQuestion`](questions.md), [`rg.TermsMetadataProperty`](metadata_property.md), and [`rg.VectorField`](vectors.md) class documentation.
 
 ---

--- a/src/argilla_sdk/datasets/_resource.py
+++ b/src/argilla_sdk/datasets/_resource.py
@@ -133,7 +133,7 @@ class Dataset(Resource):
         self.settings.allow_extra_metadata = value
 
     @property
-    def schema(self):
+    def schema(self) -> dict:
         return self.settings.schema
 
     #####################

--- a/src/argilla_sdk/settings/_resource.py
+++ b/src/argilla_sdk/settings/_resource.py
@@ -331,10 +331,10 @@ class Settings(Resource):
 
         return guidelines
 
-    def __serialize_fields(self, fields):
+    def __serialize_fields(self, fields: List[FieldType]):
         return [field.serialize() for field in fields]
 
-    def __serialize_questions(self, questions):
+    def __serialize_questions(self, questions: List[QuestionType]):
         return [question.serialize() for question in questions]
 
     #####################

--- a/tests/integration/test_create_datasets.py
+++ b/tests/integration/test_create_datasets.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import uuid
+from datetime import datetime
 
 import pytest
 
@@ -28,8 +30,9 @@ def clean_datasets(client: Argilla):
 
 class TestCreateDatasets:
     def test_create_dataset(self, client: Argilla):
+        dataset_name = f"test_dataset_{uuid.uuid4()}"
         dataset = Dataset(
-            name="test_dataset",
+            name=dataset_name,
             settings=Settings(
                 fields=[TextField(name="test_field")],
                 questions=[RatingQuestion(name="test_question", values=[1, 2, 3, 4, 5])],
@@ -40,16 +43,18 @@ class TestCreateDatasets:
         assert dataset in client.datasets
         assert dataset.exists()
 
-        created_dataset = client.datasets(name="test_dataset")
+        created_dataset = client.datasets(name=dataset_name)
         assert created_dataset.settings == dataset.settings
 
     def test_create_multiple_dataset_with_same_settings(self, client: Argilla):
+        dataset_name = f"test_dataset_{uuid.uuid4()}"
+
         settings = Settings(
             fields=[TextField(name="text")],
             questions=[RatingQuestion(name="question", values=[1, 2, 3, 4, 5])],
         )
-        dataset = Dataset(name="test_dataset", settings=settings, client=client).create()
-        dataset2 = Dataset(name="test_dataset2", settings=settings, client=client).create()
+        dataset = Dataset(name=dataset_name, settings=settings, client=client).create()
+        dataset2 = Dataset(name=f"{dataset_name}_2", settings=settings, client=client).create()
 
         assert dataset in client.datasets
         assert dataset2 in client.datasets
@@ -67,8 +72,9 @@ class TestCreateDatasets:
             assert schema["question"].values == [1, 2, 3, 4, 5]
 
     def test_create_dataset_from_existing_dataset(self, client: Argilla):
+        dataset_name = f"test_dataset_{uuid.uuid4()}"
         dataset = Dataset(
-            name="test_dataset",
+            name=dataset_name,
             settings=Settings(
                 fields=[TextField(name="text")],
                 questions=[RatingQuestion(name="question", values=[1, 2, 3, 4, 5])],
@@ -78,7 +84,7 @@ class TestCreateDatasets:
         assert dataset in client.datasets
         created_dataset = client.datasets(dataset.name)
 
-        dataset_copy = Dataset(name="test_dataset_copy", settings=created_dataset.settings, client=client).create()
+        dataset_copy = Dataset(name=f"{dataset.name}_copy", settings=created_dataset.settings, client=client).create()
         assert dataset_copy in client.datasets
 
         schema = dataset_copy.schema

--- a/tests/integration/test_create_datasets.py
+++ b/tests/integration/test_create_datasets.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import uuid
-from datetime import datetime
 
 import pytest
 


### PR DESCRIPTION
This PR adds more `rg.Settings` usage examples, covering how to create multiple datasets with the same settings or create a new dataset from an existing one.