### PR TITLE
[BUGFIX] Support update record metadata

### DIFF
--- a/src/argilla_sdk/records/_resource.py
+++ b/src/argilla_sdk/records/_resource.py
@@ -14,7 +14,7 @@
 
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union, Iterable
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Iterable
 from uuid import UUID, uuid4
 
 from argilla_sdk._models import (
@@ -450,33 +450,27 @@ class RecordVectors:
         return {vector.name: f"{len(vector.values)}" for vector in self.__vectors}.__repr__()
 
 
-class RecordMetadata:
+class RecordMetadata(dict):
     """This is a container class for the metadata of a Record."""
 
-    __metadata_map: Dict[str, MetadataValue]
-    __metadata_models: List[MetadataModel]
-
     def __init__(self, metadata: Optional[Dict[str, MetadataValue]] = None) -> None:
-        self.__metadata_map = metadata or {}
-        for key, value in self.__metadata_map.items():
-            setattr(self, key, value)
-        self.__metadata_models = [MetadataModel(name=key, value=value) for key, value in self.__metadata_map.items()]
+        super().__init__(metadata)
+
+    def __getattr__(self, item: str):
+        return self[item]
+
+    def __setattr__(self, key: str, value: MetadataValue):
+        self[key] = value
+
+    def __iter__(self) -> Iterable[MetadataModel]:
+        return iter(self.models)
+
+    def __len__(self) -> int:
+        return len(self.models)
+
+    def to_dict(self) -> Dict[str, MetadataValue]:
+        return dict(self)
 
     @property
     def models(self) -> List[MetadataModel]:
-        return self.__metadata_models
-
-    def to_dict(self) -> Dict[str, MetadataValue]:
-        return {meta.name: meta.value for meta in self.__metadata_models}
-
-    def __iter__(self) -> Iterable[MetadataModel]:
-        return iter(self.__metadata_models)
-
-    def __getitem__(self, key: str) -> MetadataValue:
-        return self.__metadata_map[key]
-
-    def __len__(self) -> int:
-        return len(self.__metadata_models)
-
-    def __repr__(self) -> Generator:
-        return self.to_dict().__repr__()
+        return [MetadataModel(name=key, value=value) for key, value in self.items()]

--- a/src/argilla_sdk/records/_resource.py
+++ b/src/argilla_sdk/records/_resource.py
@@ -454,19 +454,13 @@ class RecordMetadata(dict):
     """This is a container class for the metadata of a Record."""
 
     def __init__(self, metadata: Optional[Dict[str, MetadataValue]] = None) -> None:
-        super().__init__(metadata)
+        super().__init__(metadata or {})
 
     def __getattr__(self, item: str):
         return self[item]
 
     def __setattr__(self, key: str, value: MetadataValue):
         self[key] = value
-
-    def __iter__(self) -> Iterable[MetadataModel]:
-        return iter(self.models)
-
-    def __len__(self) -> int:
-        return len(self.models)
 
     def to_dict(self) -> Dict[str, MetadataValue]:
         return dict(self)

--- a/tests/unit/test_resources/test_records.py
+++ b/tests/unit/test_resources/test_records.py
@@ -44,7 +44,7 @@ class TestRecords:
         record.metadata["new-key"] = "new_value"
 
         assert record.metadata == {"key": "new_value", "new-key": "new_value"}
-        assert [m for m in record.metadata] == [
+        assert record.metadata.models == [
             MetadataModel(name="key", value="new_value"),
             MetadataModel(name="new-key", value="new_value"),
         ]
@@ -56,7 +56,7 @@ class TestRecords:
         record.metadata.new_key = "new_value"
 
         assert record.metadata == {"key": "new_value", "new_key": "new_value"}
-        assert [m for m in record.metadata] == [
+        assert record.metadata.models == [
             MetadataModel(name="key", value="new_value"),
             MetadataModel(name="new_key", value="new_value"),
         ]

--- a/tests/unit/test_resources/test_records.py
+++ b/tests/unit/test_resources/test_records.py
@@ -15,6 +15,7 @@
 import uuid
 
 from argilla_sdk import Record, Suggestion, Response
+from argilla_sdk._models import MetadataModel
 
 
 class TestRecords:
@@ -35,3 +36,27 @@ class TestRecords:
             "suggestions={'question': {'value': 'answer', 'score': None, 'agent': None}},"
             f"responses={{'question': [{{'value': 'answer'}}]}})"
         )
+
+    def test_update_record_metadata_by_key(self):
+        record = Record(fields={"name": "John", "age": "30"}, metadata={"key": "value"})
+
+        record.metadata["key"] = "new_value"
+        record.metadata["new-key"] = "new_value"
+
+        assert record.metadata == {"key": "new_value", "new-key": "new_value"}
+        assert [m for m in record.metadata] == [
+            MetadataModel(name="key", value="new_value"),
+            MetadataModel(name="new-key", value="new_value"),
+        ]
+
+    def test_update_record_metadata_by_attribute(self):
+        record = Record(fields={"name": "John", "age": "30"}, metadata={"key": "value"})
+
+        record.metadata.key = "new_value"
+        record.metadata.new_key = "new_value"
+
+        assert record.metadata == {"key": "new_value", "new_key": "new_value"}
+        assert [m for m in record.metadata] == [
+            MetadataModel(name="key", value="new_value"),
+            MetadataModel(name="new_key", value="new_value"),
+        ]


### PR DESCRIPTION
This PR fixes the record metadata usage to support adding/updating values from a `Record` instance:

```python
record = Record(...)


record.metadata["value"] = ...
record.metadata["new-key"] =  ...

```

Since metadata is referenced as a dictionary in docs, the expected behaviour would be to work as a dictionary. 

```python
record.metadata.update({ "value", ..., "new-key":...})
```


But we also support using attributes: 
```python
record.metadata.key = ....
record.metadata.new_key = ...
```
This could be reviewed in the future (to keep it simple).


@sdiazlor I didn't find in the docs how to work with record instances and their attributes. I only see working with mapped records (dicts). I think it would be nice to have it in the docs.