### PR TITLE
[CI] Configure job to publish release

### DIFF
--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -103,7 +103,9 @@ jobs:
           cache: true
 
       - name: Publish Package to PyPI test environment 🥪
-        run: pdm publish --no-build --repository testpypi
+        run: |
+          git status
+          pdm publish --no-build --repository testpypi
 
       - name: Test Installing 🍿
         run: pip install --index-url https://test.pypi.org/simple --no-deps argilla-server==${GITHUB_REF#refs/*/v}

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -102,12 +102,19 @@ jobs:
         with:
           cache: true
 
+      - name: Read package version
+        run: |
+          PACKAGE_VERSION=$(pdm show --version)
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "Package version: $PACKAGE_VERSION"
+
       - name: Publish Package to PyPI test environment 🥪
         run: pdm publish --no-build --repository testpypi
         continue-on-error: true
 
       - name: Test Installing 🍿
-        run: pip install --index-url https://test.pypi.org/simple --no-deps -U argilla-sdk
+        run: |
+          pip install --index-url https://test.pypi.org/simple --no-deps  argilla-sdk==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
         if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -7,6 +7,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If true, the workflow will publish the package to PyPI. Default is false."
+        default: false
+
   push:
     branches: [ "main" ]
 
@@ -15,7 +21,7 @@ on:
 
   release:
     types:
-      - published
+      - "published"
 
 jobs:
   build:
@@ -71,8 +77,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }} || ${{ github.event_name == 'tag' }}
-
+    if: github.event_name == 'workflow_dispatch'
     needs:
       - build
 
@@ -103,11 +108,13 @@ jobs:
         with:
           cache: true
 
-      - name: Read package version
+      - name: Read package info
         run: |
           PACKAGE_VERSION=$(pdm show --version)
+          PACKAGE_NAME=$(pdm show --name)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo "Package version: $PACKAGE_VERSION"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+          echo "$PACKAGE_NAME==$PACKAGE_VERSION"
 
       - name: Create tag
         run: |
@@ -122,8 +129,8 @@ jobs:
 
       - name: Test Installing 🍿
         run: |
-          pip install --index-url https://test.pypi.org/simple --no-deps  argilla-sdk==$PACKAGE_VERSION
+          pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ inputs.release }}
         run: pdm publish --no-build

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -103,9 +103,7 @@ jobs:
           cache: true
 
       - name: Publish Package to PyPI test environment 🥪
-        run: |
-          git status
-          pdm publish --no-build --repository testpypi
+        run: pdm publish --no-build --repository testpypi
 
       - name: Test Installing 🍿
         run: pip install --index-url https://test.pypi.org/simple --no-deps argilla-server==${GITHUB_REF#refs/*/v}

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: true

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -72,7 +72,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
+    # if: ${{ github.event_name == 'release' }}
 
     needs:
       - build

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -8,9 +8,8 @@ concurrency:
 
 on:
   push:
-    tags:
-      - "*"
     branches: [ "main" ]
+
   pull_request:
     branches: [ "main" ]
 
@@ -82,6 +81,8 @@ jobs:
       # contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing on PyPI
       id-token: write
+      # This permission is needed for creating tags
+      contents: write
 
     defaults:
       run:
@@ -107,6 +108,13 @@ jobs:
           PACKAGE_VERSION=$(pdm show --version)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "Package version: $PACKAGE_VERSION"
+
+      - name: Create tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag -a v${{ env.PACKAGE_VERSION }} -m "Release v${{ env.PACKAGE_VERSION }}"
+          git push origin v${{ env.PACKAGE_VERSION }}
 
       - name: Publish Package to PyPI test environment 🥪
         run: pdm publish --no-build --repository testpypi

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -62,6 +62,7 @@ jobs:
           pdm build
       - name: Upload artifact
         uses: actions/upload-artifact@v4
+        # Upload the package to be used in the next jobs only once
         if: ${{ matrix.python-version == '3.8' }}
         with:
           name: argilla-sdk

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -8,9 +8,15 @@ concurrency:
 
 on:
   push:
+    tags:
+      - "*"
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -51,4 +57,55 @@ jobs:
       - name: Run integration tests
         run: |
           pdm run test tests/integration
-          
+      - name: Build package
+        run: |
+          pdm build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.python-version == '3.8' }}
+        with:
+          name: argilla-sdk
+          path: dist
+
+  # This job will publish argilla-sdk package into PyPI repository
+  publish_release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' }}
+
+    needs:
+      - build
+
+    permissions:
+      # This permission is needed for private repositories.
+      # contents: read
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPI
+      id-token: write
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout Code 🛎
+        uses: actions/checkout@v4
+
+      - name: Download python package
+        uses: actions/download-artifact@v4
+        with:
+          name: argilla-sdk
+          path: dist
+
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v4
+        with:
+          cache: true
+
+      - name: Publish Package to PyPI test environment 🥪
+        run: pdm publish --no-build --repository testpypi
+
+      - name: Test Installing 🍿
+        run: pip install --index-url https://test.pypi.org/simple --no-deps argilla-server==${GITHUB_REF#refs/*/v}
+
+      - name: Publish Package to PyPI 🥩
+        run: pdm publish --no-build

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -1,6 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-name: Test and build the `argilla-sdk` python package
+name: Build and publish the `argilla-sdk` python package
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -72,7 +72,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    # if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' }} || ${{ github.event_name == 'tag' }}
 
     needs:
       - build
@@ -104,9 +104,11 @@ jobs:
 
       - name: Publish Package to PyPI test environment 🥪
         run: pdm publish --no-build --repository testpypi
+        continue-on-error: true
 
       - name: Test Installing 🍿
-        run: pip install --index-url https://test.pypi.org/simple --no-deps argilla-server==${GITHUB_REF#refs/*/v}
+        run: pip install --index-url https://test.pypi.org/simple --no-deps -U argilla-sdk
 
       - name: Publish Package to PyPI 🥩
+        if: ${{ github.event_name == 'release' }}
         run: pdm publish --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ line-length = 120
 distribution = true
 
 [tool.pdm.version]
-source = "scm"
+source = "file"
+path = "src/argilla_sdk/__init__.py"
 
 [tool.pdm.dev-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,23 @@
 [project]
 name = "argilla-sdk"
-version = "0.1.0"
 description = "The Argilla python server SDK"
 authors = [
     {name = "Argilla", email = "contact@argilla.io"},
-]
-dependencies = [
-    "httpx>=0.26.0",
-    "pydantic>=2.6.0, <3.0.0",
 ]
 requires-python = ">=3.10,<3.12"
 readme = "README.md"
 license = {text = "Apache 2.0"}
 
+dynamic = ["version"]
+
+dependencies = [
+    "httpx>=0.26.0",
+    "pydantic>=2.6.0, <3.0.0",
+]
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-
 
 [tool.ruff]
 line-length = 120
@@ -26,6 +27,9 @@ line-length = 120
 
 [tool.pdm]
 distribution = true
+
+[tool.pdm.version]
+source = "scm"
 
 [tool.pdm.dev-dependencies]
 dev = [

--- a/src/argilla_sdk/__init__.py
+++ b/src/argilla_sdk/__init__.py
@@ -21,3 +21,6 @@ from argilla_sdk.suggestions import *  # noqa
 from argilla_sdk.responses import *  # noqa
 from argilla_sdk.records import *  # noqa
 from argilla_sdk.vectors import *  # noqa
+
+
+__version__ = "0.1.0.alpha.0"

--- a/src/argilla_sdk/__init__.py
+++ b/src/argilla_sdk/__init__.py
@@ -23,4 +23,4 @@ from argilla_sdk.records import *  # noqa
 from argilla_sdk.vectors import *  # noqa
 
 
-__version__ = "0.1.0.alpha.0"
+__version__ = "0.1.0.alpha.1"


### PR DESCRIPTION
This PR reviews the main `argilla-sdk.yaml` workflow to prepare and publish the Python package to Pypi.

The release job will be triggered manually using the [Run workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#running-a-workflow) action (for now. We should think about the release flow). The Run configuration allows one input flag, `release` which allows publishing the package in pypi.

# Notes

* The package name is `argilla-sdk` (we should adapt the naming in pyproject.toml )
* The package version is defined in[` __init__.py`](https://github.com/argilla-io/argilla-python/pull/205/files#diff-5a6f353568dab3770e94c09bfa6ce58dedf857193d22f7a6d7490a3808a39f2eR26) 
* The release workflow will create a git tag using the configured package version.
* The package will be published at https://pypi.org/ only when `release=True` (the package will be published at https://test.pypi.org/ otherwise)
* There is a python restriction on `">=3.10,<3.12"` (We should review this @burtenshaw)

See also https://github.com/argilla-io/argilla-python/issues/207