### PR TITLE
[CI] Review release workflow

### DIFF
--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -132,5 +132,5 @@ jobs:
           pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
-        if: ${{ inputs.release }}
+        if: ${{ inputs.release == 'true' }}
         run: pdm publish --no-build

--- a/.github/workflows/argilla-sdk.yml
+++ b/.github/workflows/argilla-sdk.yml
@@ -120,8 +120,8 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a v${{ env.PACKAGE_VERSION }} -m "Release v${{ env.PACKAGE_VERSION }}"
-          git push origin v${{ env.PACKAGE_VERSION }}
+          git tag -f -a v${{ env.PACKAGE_VERSION }} -m "Release v${{ env.PACKAGE_VERSION }}"
+          git push -f origin v${{ env.PACKAGE_VERSION }}
 
       - name: Publish Package to PyPI test environment 🥪
         run: pdm publish --no-build --repository testpypi

--- a/src/argilla_sdk/__init__.py
+++ b/src/argilla_sdk/__init__.py
@@ -23,4 +23,4 @@ from argilla_sdk.records import *  # noqa
 from argilla_sdk.vectors import *  # noqa
 
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a3"

--- a/src/argilla_sdk/__init__.py
+++ b/src/argilla_sdk/__init__.py
@@ -23,4 +23,4 @@ from argilla_sdk.records import *  # noqa
 from argilla_sdk.vectors import *  # noqa
 
 
-__version__ = "0.1.0.alpha.1"
+__version__ = "0.1.0a2"


### PR DESCRIPTION
This PR fixes some errors found when testing the Release workflow defined in https://github.com/argilla-io/argilla-python/pull/205

The pipeline is working as expected. 
1. [Here](https://github.com/argilla-io/argilla-python/actions/runs/9206443841/job/25324426039) an example with `release=false` to run the workflow publishing only in tests.pypi.org.
2. and [here](https://github.com/argilla-io/argilla-python/actions/runs/9206728886/job/25325317050) the same version published to pypi.org.
 
To run these workflows you can use the [GitHub CLI](https://cli.github.com/) as follows:
1. publish without release in pypi.org
```bash
gh workflow run argilla-sdk.yml --ref release/0.1.0 -f release=false
```
we use the branch `release/0.1.0` as the ref branch for running the workflow. Otherwise, the default would be `main`

2. publish the release on pypi.org.
```bash
gh workflow run argilla-sdk.yml --ref release/0.1.0 -f release=true
```

You can see the results at https://pypi.org/project/argilla-sdk/