### PR TITLE
[BUGFIX] Avoid using generics

### DIFF
--- a/src/argilla_sdk/records/_dataset_records.py
+++ b/src/argilla_sdk/records/_dataset_records.py
@@ -19,13 +19,15 @@ from uuid import UUID
 
 from argilla_sdk._api import RecordsAPI
 from argilla_sdk._helpers._mixins import LoggingMixin
-from argilla_sdk._models import RecordModel
+from argilla_sdk._models import RecordModel, MetadataValue
 from argilla_sdk.client import Argilla
 from argilla_sdk.records._io import HFDatasetsIO, GenericIO, JsonIO, HFDataset
 from argilla_sdk.records._resource import Record
 from argilla_sdk.records._search import Query
 from argilla_sdk.responses import Response
-from argilla_sdk.settings import MetadataType, QuestionType, TextField, VectorField
+from argilla_sdk.settings import TextField, VectorField
+from argilla_sdk.settings._metadata import MetadataPropertyBase
+from argilla_sdk.settings._question import QuestionPropertyBase
 from argilla_sdk.suggestions import Suggestion
 from argilla_sdk.vectors import Vector
 
@@ -477,15 +479,15 @@ class DatasetRecords(Iterable[Record], LoggingMixin):
             # Assign the value to question, field, or response based on schema item
             if isinstance(schema_item, TextField):
                 fields[attribute] = value
-            elif isinstance(schema_item, QuestionType) and attribute_type == "response":
+            elif isinstance(schema_item, QuestionPropertyBase) and attribute_type == "response":
                 responses.append(Response(question_name=attribute, value=value, user_id=user_id))
-            elif isinstance(schema_item, QuestionType) and attribute_type is None:
+            elif isinstance(schema_item, QuestionPropertyBase) and attribute_type is None:
                 suggestion_values[attribute].update(
                     {"value": value, "question_name": attribute, "question_id": schema_item.id}
                 )
             elif isinstance(schema_item, VectorField):
                 vectors.append(Vector(name=attribute, values=value))
-            elif isinstance(schema_item, MetadataType):
+            elif isinstance(schema_item, MetadataPropertyBase):
                 metadata[attribute] = value
             else:
                 warnings.warn(message=f"Record attribute {attribute} is not in the schema or mapping so skipping.")

--- a/src/argilla_sdk/settings/_common.py
+++ b/src/argilla_sdk/settings/_common.py
@@ -55,35 +55,3 @@ class SettingsPropertyBase(Resource):
         serialized_model = super().serialize()
         serialized_model["type"] = self.type
         return serialized_model
-
-    ##############################
-    #  Private methods
-    ##############################
-
-    @staticmethod
-    def _render_values_as_options(values: Union[List[str], List[int], Dict[str, str]]) -> List[Dict[str, str]]:
-        """Render values as options for the question so that the model conforms to the API schema"""
-        if isinstance(values, dict):
-            return [{"text": value, "value": key} for key, value in values.items()]
-        elif isinstance(values, list) and all(isinstance(value, str) for value in values):
-            return [{"text": label, "value": label} for label in values]
-        elif isinstance(values, list) and all(isinstance(value, int) for value in values):
-            return [{"value": value} for value in values]
-        else:
-            raise ValueError("Invalid labels format. Please provide a list of strings or a list of dictionaries.")
-
-    @staticmethod
-    def _render_options_as_values(options: List[dict]) -> Dict[str, str]:
-        """Render options as values for the question so that the model conforms to the API schema"""
-        values = {}
-        for option in options:
-            if "text" in option:
-                values[option["value"]] = option["text"]
-            else:
-                values[option["value"]] = option["value"]
-        return values
-
-    @staticmethod
-    def _render_options_as_labels(options: List[Dict[str, str]]) -> List[str]:
-        """Render values as labels for the question so that they can be returned as a list of strings"""
-        return list(SettingsPropertyBase._render_options_as_values(options=options).keys())

--- a/src/argilla_sdk/settings/_resource.py
+++ b/src/argilla_sdk/settings/_resource.py
@@ -24,7 +24,7 @@ from argilla_sdk._models import TextFieldModel, TextQuestionModel, DatasetModel
 from argilla_sdk._resource import Resource
 from argilla_sdk.settings._field import FieldType, VectorField, field_from_model, field_from_dict
 from argilla_sdk.settings._metadata import MetadataType
-from argilla_sdk.settings._question import QuestionType, question_from_model, question_from_dict
+from argilla_sdk.settings._question import QuestionType, question_from_model, question_from_dict, QuestionPropertyBase
 
 if TYPE_CHECKING:
     from argilla_sdk.datasets import Dataset
@@ -190,7 +190,7 @@ class Settings(Resource):
 
     def question_by_id(self, question_id: UUID) -> QuestionType:
         property = self.schema_by_id.get(question_id)
-        if isinstance(property, QuestionType):
+        if isinstance(property, QuestionPropertyBase):
             return property
         raise ValueError(f"Question with id {question_id} not found")
 


### PR DESCRIPTION
Using Python 3.9 [here](https://github.com/argilla-io/argilla/actions/runs/9266930276/job/25492476379?pr=4891) we discovered an error when checking property types using Generics. 

This PR fixes the problem by using base classes for questions and metadata. A new `QuestionSettingsBase` has been defined and the render label's method have been moved there. 