### PR TITLE
[REFACTOR] Using `.model_validate` instead of deprectated `.parse_obj`

### DIFF
--- a/src/argilla_sdk/records/_search.py
+++ b/src/argilla_sdk/records/_search.py
@@ -93,7 +93,7 @@ class Filter:
 
     @property
     def model(self) -> AndFilterModel:
-        return AndFilterModel.parse_obj({"and": [condition.model for condition in self.conditions]})
+        return AndFilterModel.model_validate({"and": [condition.model for condition in self.conditions]})
 
 
 class Query:


### PR DESCRIPTION
`parse_obj` method is deprecated