### PR TITLE
[REFACTOR] Create property container abstraction

### DIFF
--- a/src/argilla_sdk/responses.py
+++ b/src/argilla_sdk/responses.py
@@ -169,7 +169,7 @@ class UserResponse(Resource):
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns the UserResponse as a dictionary"""
-        return self._model.dict()
+        return self._model.model_dump()
 
     @staticmethod
     def __responses_as_model_values(answers: List[Response]) -> Dict[str, Dict[str, Any]]:

--- a/src/argilla_sdk/settings/_metadata.py
+++ b/src/argilla_sdk/settings/_metadata.py
@@ -283,6 +283,7 @@ class MetadataField:
         }
         metadata_type = data["type"]
         try:
-            return switch[metadata_type](**data)
+            metadata_model = MetadataFieldModel(**data)
+            return switch[metadata_type].from_model(metadata_model)
         except KeyError as e:
             raise MetadataError(f"Unknown metadata property type: {metadata_type}") from e

--- a/src/argilla_sdk/settings/_resource.py
+++ b/src/argilla_sdk/settings/_resource.py
@@ -215,8 +215,8 @@ class Settings(Resource):
                 "guidelines": self.guidelines,
                 "questions": self.__serialize_questions(self.questions),
                 "fields": self.__fields.serialize(),
-                # "vectors": self.vectors.serialize(),
-                # "metadata": self.metadata.serialize(),
+                "vectors": self.vectors.serialize(),
+                "metadata": self.metadata.serialize(),
                 "allow_extra_metadata": self.allow_extra_metadata,
             }
         except Exception as e:
@@ -242,23 +242,22 @@ class Settings(Resource):
         with open(path, "r") as file:
             settings_dict = json.load(file)
 
-        questions = settings_dict.get("questions", [])
         fields = settings_dict.get("fields", [])
-        # vectors = settings_dict.get("vectors", [])
-        # metadata = settings_dict.get("metadata", [])
+        vectors = settings_dict.get("vectors", [])
+        metadata = settings_dict.get("metadata", [])
         guidelines = settings_dict.get("guidelines")
         allow_extra_metadata = settings_dict.get("allow_extra_metadata")
 
-        questions = [question_from_dict(question) for question in questions]
+        questions = [question_from_dict(question) for question in settings_dict.get("questions", [])]
         fields = [TextField.from_dict(field) for field in fields]
-        # vectors = [VectorField.from_dict(vector) for vector in vectors]
-        # metadata = [MetadataField.from_dict(metadata) for metadata in metadata]
+        vectors = [VectorField.from_dict(vector) for vector in vectors]
+        metadata = [MetadataField.from_dict(metadata) for metadata in metadata]
 
         return cls(
             questions=questions,
             fields=fields,
-            # vectors=vectors,
-            # metadata=metadata,
+            vectors=vectors,
+            metadata=metadata,
             guidelines=guidelines,
             allow_extra_metadata=allow_extra_metadata,
         )

--- a/src/argilla_sdk/settings/_resource.py
+++ b/src/argilla_sdk/settings/_resource.py
@@ -176,11 +176,11 @@ class Settings(Resource):
     def create(self) -> "Settings":
         self.validate()
 
+        self._update_dataset_related_attributes()
         self._create_fields()
         self._create_vectors()
         self._create_metadata()
         self._create_questions()
-        self._update_dataset_related_attributes()
 
         self._update_last_api_call()
         return self
@@ -188,10 +188,10 @@ class Settings(Resource):
     def update(self) -> "Resource":
         self.validate()
 
+        self._update_dataset_related_attributes()
         self._upsert_fields()
         self._upsert_vectors()
         self._upsert_metadata()
-        self._update_dataset_related_attributes()
 
         self._update_last_api_call()
         return self

--- a/src/argilla_sdk/suggestions.py
+++ b/src/argilla_sdk/suggestions.py
@@ -125,7 +125,7 @@ class Suggestion(Resource):
         model.question_name = question.name
         model.value = cls.__from_model_value(model.value, question)
 
-        return cls(**model.dict())
+        return cls(**model.model_dump())
 
     def api_model(self) -> SuggestionModel:
         if self.record is None or self.record.dataset is None:

--- a/tests/integration/test_export_dataset.py
+++ b/tests/integration/test_export_dataset.py
@@ -50,17 +50,17 @@ def test_export_dataset_to_disk(dataset: rg.Dataset):
         {
             "text": "Hello World, how are you?",
             "label": "positive",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
             "label": "negative",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
             "label": "positive",
-            "external_id": uuid.uuid4(),
+            "id": uuid.uuid4(),
         },
     ]
     dataset.records.add(records=mock_data)

--- a/tests/integration/test_update_dataset_settings.py
+++ b/tests/integration/test_update_dataset_settings.py
@@ -35,18 +35,18 @@ class TestUpdateDatasetFields:
         settings = dataset.settings
 
         settings.schema["text"].use_markdown = True
-        dataset.settings.vectors.append(VectorField(name="vector", dimensions=10))
-        dataset.settings.metadata.append(FloatMetadataProperty(name="metadata"))
+        dataset.settings.vectors.add(VectorField(name="vector", dimensions=10))
+        dataset.settings.metadata.add(FloatMetadataProperty(name="metadata"))
         dataset.settings.update()
 
         dataset = client.datasets(dataset.name)
-        assert dataset.schema["text"].use_markdown is True
-        assert dataset.schema["vector"].dimensions == 10
-        assert isinstance(dataset.schema["metadata"], FloatMetadataProperty)
-
         settings = dataset.settings
-        settings.schema["vector"].title = "A new title for vector"
+        assert settings.fields.text.use_markdown is True
+        assert settings.vectors.vector.dimensions == 10
+        assert isinstance(settings.metadata.metadata, FloatMetadataProperty)
+
+        settings.vectors.vector.title = "A new title for vector"
 
         settings.update()
         dataset = client.datasets(dataset.name)
-        assert dataset.schema["vector"].title == "A new title for vector"
+        assert dataset.settings.vectors.vector.title == "A new title for vector"

--- a/tests/unit/export/test_settings_export_import_compatibillity.py
+++ b/tests/unit/export/test_settings_export_import_compatibillity.py
@@ -76,6 +76,22 @@ def dataset(httpx_mock: HTTPXMock, settings) -> rg.Dataset:
         yield dataset
 
 
+def test_settings_to_json(settings):
+    with TemporaryDirectory() as temp_dir:
+        temp_file_path = f"{temp_dir}/settings.json"
+        settings.to_json(temp_file_path)
+        with open(temp_file_path, "r") as f:
+            settings_json = f.read()
+
+            assert "fields" in settings_json
+            assert "questions" in settings_json
+            assert "metadata" in settings_json
+            assert "vectors" in settings_json
+
+        loaded_settings = rg.Settings.from_json(temp_file_path)
+        assert settings == loaded_settings
+
+
 def test_export_settings_from_disk(settings):
     with TemporaryDirectory() as temp_dir:
         temp_file_path = f"{temp_dir}/settings.json"

--- a/tests/unit/test_resources/test_datasets.py
+++ b/tests/unit/test_resources/test_datasets.py
@@ -74,33 +74,6 @@ def dataset(httpx_mock: HTTPXMock) -> rg.Dataset:
 
 
 class TestDatasets:
-    def mock_dataset_settings(self, httpx_mock: HTTPXMock, dataset_id: uuid.UUID, dataset_dict: dict):
-        mock_field = {
-            "id": str(uuid.uuid4()),
-            "name": "text",
-            "settings": {"type": "text", "use_markdown": True},
-            "inserted_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat(),
-        }
-        mock_question = {
-            "id": str(uuid.uuid4()),
-            "name": "response",
-            "settings": {"type": "text", "use_markdown": True},
-            "inserted_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat(),
-        }
-        httpx_mock.add_response(
-            json=dataset_dict,
-            url=self.url(f"/api/v1/datasets/{dataset_id}"),
-            method="PATCH",
-            status_code=200,
-        )
-        httpx_mock.add_response(
-            json=mock_field, url=self.url(f"/api/v1/datasets/{dataset_id}/fields"), method="POST", status_code=200
-        )
-        httpx_mock.add_response(
-            json=mock_question, url=self.url(f"/api/v1/datasets/{dataset_id}/questions"), method="POST", status_code=200
-        )
 
     def url(self, path: str) -> str:
         return f"http://test_url{path}"
@@ -148,7 +121,7 @@ class TestDatasets:
                 method="PUT",
                 status_code=200,
             )
-            self.mock_dataset_settings(httpx_mock, mock_dataset_id, mock_return_value)
+            self._mock_dataset_settings(httpx_mock, mock_dataset_id, mock_return_value)
         with httpx.Client():
             if expected_exception:
                 with pytest.raises(expected_exception=expected_exception) as excinfo:
@@ -186,11 +159,31 @@ class TestDatasets:
         httpx_mock.add_response(
             json=mock_patch_return_value,
             url=self.url(f"/api/v1/datasets/{mock_dataset_id}"),
+            method="GET",
+            status_code=200,
+        )
+        httpx_mock.add_response(
+            json=mock_patch_return_value,
+            url=self.url(f"/api/v1/datasets/{mock_dataset_id}"),
             method="PATCH",
             status_code=status_code,
         )
 
         dataset.id = mock_dataset_id
+        if status_code == 200:
+            httpx_mock.add_response(
+                json={
+                    "id": str(uuid.uuid4()),
+                    "name": "text",
+                    "settings": {"type": "text", "use_markdown": True},
+                    "inserted_at": datetime.utcnow().isoformat(),
+                    "updated_at": datetime.utcnow().isoformat(),
+                },
+                url=self.url(f"/api/v1/datasets/{mock_dataset_id}/fields"),
+                method="POST",
+                status_code=200,
+            )
+
         with httpx.Client():
             if expected_exception:
                 with pytest.raises(expected_exception=expected_exception) as excinfo:
@@ -232,6 +225,34 @@ class TestDatasets:
             else:
                 dataset.delete()
                 assert dataset.name == mock_return_value["name"]
+
+    def _mock_dataset_settings(self, httpx_mock: HTTPXMock, dataset_id: uuid.UUID, dataset_dict: dict):
+        mock_field = {
+            "id": str(uuid.uuid4()),
+            "name": "text",
+            "settings": {"type": "text", "use_markdown": True},
+            "inserted_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        mock_question = {
+            "id": str(uuid.uuid4()),
+            "name": "response",
+            "settings": {"type": "text", "use_markdown": True},
+            "inserted_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        httpx_mock.add_response(
+            json=dataset_dict,
+            url=self.url(f"/api/v1/datasets/{dataset_id}"),
+            method="PATCH",
+            status_code=200,
+        )
+        httpx_mock.add_response(
+            json=mock_field, url=self.url(f"/api/v1/datasets/{dataset_id}/fields"), method="POST", status_code=200
+        )
+        httpx_mock.add_response(
+            json=mock_question, url=self.url(f"/api/v1/datasets/{dataset_id}/questions"), method="POST", status_code=200
+        )
 
 
 class TestDatasetsAPI:

--- a/tests/unit/test_resources/test_datasets.py
+++ b/tests/unit/test_resources/test_datasets.py
@@ -74,7 +74,6 @@ def dataset(httpx_mock: HTTPXMock) -> rg.Dataset:
 
 
 class TestDatasets:
-
     def url(self, path: str) -> str:
         return f"http://test_url{path}"
 

--- a/tests/unit/test_settings/test_settings.py
+++ b/tests/unit/test_settings/test_settings.py
@@ -20,8 +20,8 @@ from argilla_sdk._exceptions import SettingsError
 class TestSettings:
     def test_init_settings(self):
         settings = rg.Settings()
-        assert settings.fields == []
-        assert settings.questions == []
+        assert len(settings.fields) == 0
+        assert len(settings.questions) == 0
 
     def test_with_guidelines(self):
         mock_guidelines = "This is a guideline"


### PR DESCRIPTION
This PR gathers the feedback from [this](https://github.com/argilla-io/argilla-python/pull/232#issuecomment-2139345583) comment and rewrite settings fields, vectors and metadata using a class container pattern: `SettingsProperties`.

The same class is used for the different property groups. But this could be changed for code readability and usage.